### PR TITLE
Replace WebSockets with SSE

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,10 +24,10 @@
       "resolved": "https://registry.npmjs.org/@material/button/-/button-0.29.0.tgz",
       "integrity": "sha512-tz73dUQadF8UBccbyctWpk4QNw5ypR3RuTbSsC0fTj2MN0/tEuPME/QXxvpaN3+rurdnbuhpzGOxS7nzDZL7fw==",
       "requires": {
-        "@material/elevation": "0.28.0",
-        "@material/ripple": "0.29.0",
-        "@material/theme": "0.29.0",
-        "@material/typography": "0.28.0"
+        "@material/elevation": "^0.28.0",
+        "@material/ripple": "^0.29.0",
+        "@material/theme": "^0.29.0",
+        "@material/typography": "^0.28.0"
       }
     },
     "@material/card": {
@@ -35,10 +35,10 @@
       "resolved": "https://registry.npmjs.org/@material/card/-/card-0.29.0.tgz",
       "integrity": "sha512-WOhrcEazNIT0/6k5Ga3h0tcx3Y+B3tJm4HjfTKXN0GVWV1/JwZ4duEKOxWnso+/iuvPQt2bk4EGvI/9P/N8TxQ==",
       "requires": {
-        "@material/elevation": "0.28.0",
-        "@material/rtl": "0.29.0",
-        "@material/theme": "0.29.0",
-        "@material/typography": "0.28.0"
+        "@material/elevation": "^0.28.0",
+        "@material/rtl": "^0.29.0",
+        "@material/theme": "^0.29.0",
+        "@material/typography": "^0.28.0"
       }
     },
     "@material/checkbox": {
@@ -46,12 +46,12 @@
       "resolved": "https://registry.npmjs.org/@material/checkbox/-/checkbox-0.29.0.tgz",
       "integrity": "sha512-PStlwlyRBcY8knFraYU4kWeKyJIS0JccSFbmWC+4853hkSIgyUieHLSWMv5giFFKZtnAPYJjbyPF0mxPrmeTNA==",
       "requires": {
-        "@material/animation": "0.25.0",
-        "@material/base": "0.29.0",
-        "@material/ripple": "0.29.0",
-        "@material/rtl": "0.29.0",
-        "@material/selection-control": "0.29.0",
-        "@material/theme": "0.29.0"
+        "@material/animation": "^0.25.0",
+        "@material/base": "^0.29.0",
+        "@material/ripple": "^0.29.0",
+        "@material/rtl": "^0.29.0",
+        "@material/selection-control": "^0.29.0",
+        "@material/theme": "^0.29.0"
       }
     },
     "@material/dialog": {
@@ -59,14 +59,14 @@
       "resolved": "https://registry.npmjs.org/@material/dialog/-/dialog-0.29.0.tgz",
       "integrity": "sha512-bAoImCF5HO2gWdDgtobWi0hI1zVFSM0MOAT2QUPXKAu/KrYFwZV3AG04P3S73t38lR763dpmX8xYzaE+P4OIYA==",
       "requires": {
-        "@material/animation": "0.25.0",
-        "@material/base": "0.29.0",
-        "@material/elevation": "0.28.0",
-        "@material/ripple": "0.29.0",
-        "@material/rtl": "0.29.0",
-        "@material/theme": "0.29.0",
-        "@material/typography": "0.1.1",
-        "focus-trap": "2.4.3"
+        "@material/animation": "^0.25.0",
+        "@material/base": "^0.29.0",
+        "@material/elevation": "^0.28.0",
+        "@material/ripple": "^0.29.0",
+        "@material/rtl": "^0.29.0",
+        "@material/theme": "^0.29.0",
+        "@material/typography": "^0.1.1",
+        "focus-trap": "^2.3.0"
       },
       "dependencies": {
         "@material/typography": {
@@ -81,12 +81,12 @@
       "resolved": "https://registry.npmjs.org/@material/drawer/-/drawer-0.29.0.tgz",
       "integrity": "sha512-aBbsbqZ1K50R5f915z7+O4InKDLQ/u7jNDNGdsLugRuwbDda20K54tAMmjU8ELpd1Y22CDvuk1OJHb6WggjiJQ==",
       "requires": {
-        "@material/animation": "0.25.0",
-        "@material/base": "0.29.0",
-        "@material/elevation": "0.28.0",
-        "@material/rtl": "0.29.0",
-        "@material/theme": "0.29.0",
-        "@material/typography": "0.28.0"
+        "@material/animation": "^0.25.0",
+        "@material/base": "^0.29.0",
+        "@material/elevation": "^0.28.0",
+        "@material/rtl": "^0.29.0",
+        "@material/theme": "^0.29.0",
+        "@material/typography": "^0.28.0"
       }
     },
     "@material/elevation": {
@@ -94,8 +94,8 @@
       "resolved": "https://registry.npmjs.org/@material/elevation/-/elevation-0.28.0.tgz",
       "integrity": "sha512-U2utCuMDDhrJ8Cyisz16GAejN9h9xyS4jvVkt2uIOUyPZRjnaJyoAbpyf0mOzFxIdBuRpNGJYm2PoAwHsSA+xw==",
       "requires": {
-        "@material/animation": "0.25.0",
-        "@material/theme": "0.4.0"
+        "@material/animation": "^0.25.0",
+        "@material/theme": "^0.4.0"
       },
       "dependencies": {
         "@material/theme": {
@@ -110,10 +110,10 @@
       "resolved": "https://registry.npmjs.org/@material/fab/-/fab-0.29.0.tgz",
       "integrity": "sha512-Pnbe2qKAxAQD8dCH0GlFZrZBN9xPhgXGamokkOjyYuWE7RHacljP69PYknVz8wW5pWMnG1Y8AoSV0U7J/8Fjyg==",
       "requires": {
-        "@material/animation": "0.25.0",
-        "@material/elevation": "0.28.0",
-        "@material/ripple": "0.29.0",
-        "@material/theme": "0.29.0"
+        "@material/animation": "^0.25.0",
+        "@material/elevation": "^0.28.0",
+        "@material/ripple": "^0.29.0",
+        "@material/theme": "^0.29.0"
       }
     },
     "@material/form-field": {
@@ -121,11 +121,11 @@
       "resolved": "https://registry.npmjs.org/@material/form-field/-/form-field-0.29.0.tgz",
       "integrity": "sha512-IVYNJHDHaL9fTCEV8SYk6dImXGpXYWu4esT0CTxNpglZ8vJUrE749iH8BdoPEYRBs3/4pVU1J6OiTGvtb0FhTw==",
       "requires": {
-        "@material/base": "0.29.0",
-        "@material/rtl": "0.29.0",
-        "@material/selection-control": "0.29.0",
-        "@material/theme": "0.29.0",
-        "@material/typography": "0.28.0"
+        "@material/base": "^0.29.0",
+        "@material/rtl": "^0.29.0",
+        "@material/selection-control": "^0.29.0",
+        "@material/theme": "^0.29.0",
+        "@material/typography": "^0.28.0"
       }
     },
     "@material/grid-list": {
@@ -133,10 +133,10 @@
       "resolved": "https://registry.npmjs.org/@material/grid-list/-/grid-list-0.29.0.tgz",
       "integrity": "sha512-MFFNePCtHVVcaC8cu25ukYPWde50UnfFl1Cv/sH+4hgkC+EBrCzrYcCwV/WtyFduv0HbgwVe6tdw9EXph+3zbQ==",
       "requires": {
-        "@material/base": "0.29.0",
-        "@material/rtl": "0.29.0",
-        "@material/theme": "0.29.0",
-        "@material/typography": "0.28.0"
+        "@material/base": "^0.29.0",
+        "@material/rtl": "^0.29.0",
+        "@material/theme": "^0.29.0",
+        "@material/typography": "^0.28.0"
       }
     },
     "@material/icon-toggle": {
@@ -144,10 +144,10 @@
       "resolved": "https://registry.npmjs.org/@material/icon-toggle/-/icon-toggle-0.29.0.tgz",
       "integrity": "sha512-zp+/ZnFNnVQ4ceHxIrhyNWcGMt5JrFdp0Ay1WSSaFak+xszEhFDVEskp1Y8M0N5+QtArTPVCfyqp9Hh4KKtbCw==",
       "requires": {
-        "@material/animation": "0.25.0",
-        "@material/base": "0.29.0",
-        "@material/ripple": "0.29.0",
-        "@material/theme": "0.29.0"
+        "@material/animation": "^0.25.0",
+        "@material/base": "^0.29.0",
+        "@material/ripple": "^0.29.0",
+        "@material/theme": "^0.29.0"
       }
     },
     "@material/layout-grid": {
@@ -160,9 +160,9 @@
       "resolved": "https://registry.npmjs.org/@material/linear-progress/-/linear-progress-0.29.0.tgz",
       "integrity": "sha512-RPfMQNSA8lSeKKI9KBd00EfxdBWxLJYUnGShaGc92I1e+ZCGu3CPB1RpRCrkPpwE0nhgmZBK96AHfOhtMOejMA==",
       "requires": {
-        "@material/animation": "0.25.0",
-        "@material/base": "0.29.0",
-        "@material/theme": "0.29.0"
+        "@material/animation": "^0.25.0",
+        "@material/base": "^0.29.0",
+        "@material/theme": "^0.29.0"
       }
     },
     "@material/list": {
@@ -170,10 +170,10 @@
       "resolved": "https://registry.npmjs.org/@material/list/-/list-0.29.0.tgz",
       "integrity": "sha512-pursi+JQuSv4pXOGUKvNWtWa7sFXoHCiXt0mg7kLxdanI37x7SV7TSFRifKT57fJlQxmNRGy6blbTP7celO7mg==",
       "requires": {
-        "@material/ripple": "0.29.0",
-        "@material/rtl": "0.29.0",
-        "@material/theme": "0.29.0",
-        "@material/typography": "0.28.0"
+        "@material/ripple": "^0.29.0",
+        "@material/rtl": "^0.29.0",
+        "@material/theme": "^0.29.0",
+        "@material/typography": "^0.28.0"
       }
     },
     "@material/menu": {
@@ -181,11 +181,11 @@
       "resolved": "https://registry.npmjs.org/@material/menu/-/menu-0.29.0.tgz",
       "integrity": "sha512-wcwnjxcxabSdSeg2gpFC0EO+mUnq42hun7lAKpGzwxHw1Qe7ctqLzGqX+cnb2fJHTa7dsySTHiOeLzWMZH0TIg==",
       "requires": {
-        "@material/animation": "0.25.0",
-        "@material/base": "0.29.0",
-        "@material/elevation": "0.28.0",
-        "@material/theme": "0.29.0",
-        "@material/typography": "0.28.0"
+        "@material/animation": "^0.25.0",
+        "@material/base": "^0.29.0",
+        "@material/elevation": "^0.28.0",
+        "@material/theme": "^0.29.0",
+        "@material/typography": "^0.28.0"
       }
     },
     "@material/radio": {
@@ -193,11 +193,11 @@
       "resolved": "https://registry.npmjs.org/@material/radio/-/radio-0.29.0.tgz",
       "integrity": "sha512-brQvhFWVPqhlooGl5lhrxh/kNC7zyznSYsu+Ni1JDQRKN9lpABFJhLNmqX8twhhIifVTiEFPNznYvBJWHxF8Lg==",
       "requires": {
-        "@material/animation": "0.25.0",
-        "@material/base": "0.29.0",
-        "@material/ripple": "0.29.0",
-        "@material/selection-control": "0.29.0",
-        "@material/theme": "0.29.0"
+        "@material/animation": "^0.25.0",
+        "@material/base": "^0.29.0",
+        "@material/ripple": "^0.29.0",
+        "@material/selection-control": "^0.29.0",
+        "@material/theme": "^0.29.0"
       }
     },
     "@material/ripple": {
@@ -205,8 +205,8 @@
       "resolved": "https://registry.npmjs.org/@material/ripple/-/ripple-0.29.0.tgz",
       "integrity": "sha512-AUFe/IioOSsKK2MwS0g78Nj6iHB87TgX5OvNCP1B+aYSJXmB3LqB5EXQ6THXIt5FIvzR4EV6H5dL93W5FvMTkA==",
       "requires": {
-        "@material/base": "0.29.0",
-        "@material/theme": "0.29.0"
+        "@material/base": "^0.29.0",
+        "@material/theme": "^0.29.0"
       }
     },
     "@material/rtl": {
@@ -219,14 +219,14 @@
       "resolved": "https://registry.npmjs.org/@material/select/-/select-0.29.0.tgz",
       "integrity": "sha512-FdDrxlepB5ZMfjXWgeOw82JR9jz6EORZeoLacsTOqFPqKlSInZnwUg5SHPdGRAtgXOjjKqb9WY5X+BJFeLIqhA==",
       "requires": {
-        "@material/animation": "0.25.0",
-        "@material/base": "0.29.0",
-        "@material/list": "0.29.0",
-        "@material/menu": "0.29.0",
-        "@material/ripple": "0.29.0",
-        "@material/rtl": "0.29.0",
-        "@material/theme": "0.29.0",
-        "@material/typography": "0.28.0"
+        "@material/animation": "^0.25.0",
+        "@material/base": "^0.29.0",
+        "@material/list": "^0.29.0",
+        "@material/menu": "^0.29.0",
+        "@material/ripple": "^0.29.0",
+        "@material/rtl": "^0.29.0",
+        "@material/theme": "^0.29.0",
+        "@material/typography": "^0.28.0"
       }
     },
     "@material/selection-control": {
@@ -234,7 +234,7 @@
       "resolved": "https://registry.npmjs.org/@material/selection-control/-/selection-control-0.29.0.tgz",
       "integrity": "sha512-bF6NrvTNntrCIJqQk6jUAsz1zzXHjGAXMyFlYW7/7tJCKC3rrNrvx1c0abAarQakLSF8eQqL9CtKEPl+drfpcw==",
       "requires": {
-        "@material/ripple": "0.29.0"
+        "@material/ripple": "^0.29.0"
       }
     },
     "@material/slider": {
@@ -242,10 +242,10 @@
       "resolved": "https://registry.npmjs.org/@material/slider/-/slider-0.29.0.tgz",
       "integrity": "sha512-rJTTptTlabt6RWuuGEePM+kckOnB95hK6tWIdiQFgjv/y1usmkQSC3OdtacQMw4SNysIWpECdUyBrhjkUH/syg==",
       "requires": {
-        "@material/animation": "0.25.0",
-        "@material/base": "0.29.0",
-        "@material/rtl": "0.29.0",
-        "@material/theme": "0.29.0"
+        "@material/animation": "^0.25.0",
+        "@material/base": "^0.29.0",
+        "@material/rtl": "^0.29.0",
+        "@material/theme": "^0.29.0"
       }
     },
     "@material/snackbar": {
@@ -253,11 +253,11 @@
       "resolved": "https://registry.npmjs.org/@material/snackbar/-/snackbar-0.29.0.tgz",
       "integrity": "sha512-+ZNyGiR/nejEBx1GMoXPvqube7w/+pvY0go5qfdho3L5jBy9j+Y81NqgVHoFr5iar6hiDtwoSxTFfMXfW0hsnA==",
       "requires": {
-        "@material/animation": "0.25.0",
-        "@material/base": "0.29.0",
-        "@material/rtl": "0.29.0",
-        "@material/theme": "0.29.0",
-        "@material/typography": "0.28.0"
+        "@material/animation": "^0.25.0",
+        "@material/base": "^0.29.0",
+        "@material/rtl": "^0.29.0",
+        "@material/theme": "^0.29.0",
+        "@material/typography": "^0.28.0"
       }
     },
     "@material/switch": {
@@ -265,9 +265,9 @@
       "resolved": "https://registry.npmjs.org/@material/switch/-/switch-0.29.0.tgz",
       "integrity": "sha512-AlhaDK/bEVo/L9RwMZ9m7b9bTTinMJkB7a7jF6ZhKYndg+VHAesTDURH9wmkcOYS9oPAJ8dGRwEdzRGj34i2Xw==",
       "requires": {
-        "@material/animation": "0.25.0",
-        "@material/elevation": "0.28.0",
-        "@material/theme": "0.29.0"
+        "@material/animation": "^0.25.0",
+        "@material/elevation": "^0.28.0",
+        "@material/theme": "^0.29.0"
       }
     },
     "@material/tabs": {
@@ -275,12 +275,12 @@
       "resolved": "https://registry.npmjs.org/@material/tabs/-/tabs-0.29.0.tgz",
       "integrity": "sha512-hF0AfTIhCv0QFIxQfiQLqZ60wCNphmH/pU30wHYYRrPBisPuUfebgsjBULqqc8tn+BTha4eAJk0odP2PuuJaiA==",
       "requires": {
-        "@material/animation": "0.25.0",
-        "@material/base": "0.29.0",
-        "@material/ripple": "0.29.0",
-        "@material/rtl": "0.29.0",
-        "@material/theme": "0.29.0",
-        "@material/typography": "0.28.0"
+        "@material/animation": "^0.25.0",
+        "@material/base": "^0.29.0",
+        "@material/ripple": "^0.29.0",
+        "@material/rtl": "^0.29.0",
+        "@material/theme": "^0.29.0",
+        "@material/typography": "^0.28.0"
       }
     },
     "@material/textfield": {
@@ -288,12 +288,12 @@
       "resolved": "https://registry.npmjs.org/@material/textfield/-/textfield-0.29.0.tgz",
       "integrity": "sha512-XYEfRSGlCABCPeLicbnsdnaB3+BvK0LybGowFtw3Sc41OIPja5toS7K+E54leJBG6FDeI2vsney1NvyzNsIf3w==",
       "requires": {
-        "@material/animation": "0.25.0",
-        "@material/base": "0.29.0",
-        "@material/ripple": "0.29.0",
-        "@material/rtl": "0.29.0",
-        "@material/theme": "0.29.0",
-        "@material/typography": "0.28.0"
+        "@material/animation": "^0.25.0",
+        "@material/base": "^0.29.0",
+        "@material/ripple": "^0.29.0",
+        "@material/rtl": "^0.29.0",
+        "@material/theme": "^0.29.0",
+        "@material/typography": "^0.28.0"
       }
     },
     "@material/theme": {
@@ -306,11 +306,11 @@
       "resolved": "https://registry.npmjs.org/@material/toolbar/-/toolbar-0.29.0.tgz",
       "integrity": "sha512-GiIgn3AJLa9ivvel2IP67PL8HtyJtwub5eqEIKeL3fHlDtdPN+8AY65nbGpWstfNyX7O84Tv5p+STlzmDlDvEw==",
       "requires": {
-        "@material/base": "0.29.0",
-        "@material/elevation": "0.28.0",
-        "@material/rtl": "0.29.0",
-        "@material/theme": "0.29.0",
-        "@material/typography": "0.28.0"
+        "@material/base": "^0.29.0",
+        "@material/elevation": "^0.28.0",
+        "@material/rtl": "^0.29.0",
+        "@material/theme": "^0.29.0",
+        "@material/typography": "^0.28.0"
       }
     },
     "@material/typography": {
@@ -328,23 +328,18 @@
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
       "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
       "requires": {
-        "mime-types": "2.1.18",
+        "mime-types": "~2.1.18",
         "negotiator": "0.6.1"
       }
-    },
-    "after": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz",
-      "integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8="
     },
     "align-text": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "requires": {
-        "kind-of": "3.2.2",
-        "longest": "1.0.1",
-        "repeat-string": "1.6.1"
+        "kind-of": "^3.0.2",
+        "longest": "^1.0.1",
+        "repeat-string": "^1.5.2"
       }
     },
     "ansi-escapes": {
@@ -382,13 +377,8 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "requires": {
-        "sprintf-js": "1.0.3"
+        "sprintf-js": "~1.0.2"
       }
-    },
-    "arraybuffer.slice": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.7.tgz",
-      "integrity": "sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog=="
     },
     "asap": {
       "version": "2.0.6",
@@ -400,53 +390,20 @@
       "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
       "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
     },
-    "async-limiter": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
-      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
-    },
-    "backo2": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
-      "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc="
-    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
-    },
-    "base64-arraybuffer": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
-      "integrity": "sha1-c5JncZI7Whl0etZmqlzUv5xunOg="
     },
     "base64-js": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.2.tgz",
       "integrity": "sha1-Ak8Pcq+iW3X5wO5zzU9V7Bvtl4Q="
     },
-    "base64id": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/base64id/-/base64id-1.0.0.tgz",
-      "integrity": "sha1-R2iMuZu2gE8OBtPnY7HDLlfY5rY="
-    },
-    "better-assert": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
-      "integrity": "sha1-QIZrnhueC1W0gYlDEeaPr/rrxSI=",
-      "requires": {
-        "callsite": "1.0.0"
-      }
-    },
     "bindings": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.0.tgz",
       "integrity": "sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw=="
-    },
-    "blob": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz",
-      "integrity": "sha1-vPEwUspURj8w+fx+lbmkdjCpSSE="
     },
     "bops": {
       "version": "0.1.1",
@@ -462,7 +419,7 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -470,11 +427,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
       "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
-    },
-    "callsite": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
-      "integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA="
     },
     "camelcase": {
       "version": "1.2.1",
@@ -491,8 +443,8 @@
       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
       "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
       "requires": {
-        "align-text": "0.1.4",
-        "lazy-cache": "1.0.4"
+        "align-text": "^0.1.3",
+        "lazy-cache": "^1.0.3"
       }
     },
     "chalk": {
@@ -500,11 +452,11 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "requires": {
-        "ansi-styles": "2.2.1",
-        "escape-string-regexp": "1.0.5",
-        "has-ansi": "2.0.0",
-        "strip-ansi": "3.0.1",
-        "supports-color": "2.0.0"
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
       }
     },
     "cli-cursor": {
@@ -512,7 +464,7 @@
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
       "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
       "requires": {
-        "restore-cursor": "1.0.1"
+        "restore-cursor": "^1.0.1"
       }
     },
     "cli-width": {
@@ -525,8 +477,8 @@
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
       "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
       "requires": {
-        "center-align": "0.1.3",
-        "right-align": "0.1.3",
+        "center-align": "^0.1.1",
+        "right-align": "^0.1.1",
         "wordwrap": "0.0.2"
       }
     },
@@ -535,10 +487,10 @@
       "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-0.3.0.tgz",
       "integrity": "sha1-NIxhrpzb4O3+BT2R/0zFIdeQ7eg=",
       "requires": {
-        "for-own": "1.0.0",
-        "is-plain-object": "2.0.4",
-        "kind-of": "3.2.2",
-        "shallow-clone": "0.1.2"
+        "for-own": "^1.0.0",
+        "is-plain-object": "^2.0.1",
+        "kind-of": "^3.2.2",
+        "shallow-clone": "^0.1.2"
       }
     },
     "co": {
@@ -556,27 +508,12 @@
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.2.1.tgz",
       "integrity": "sha512-s8+wktIuDSLffCywiwSxQOMqtPxML11a/dtHE17tMn4B1MSWw/C22EKf7M2KGUBcDaVFEGT+S8N02geDXeuNKg=="
     },
-    "component-bind": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz",
-      "integrity": "sha1-AMYIq33Nk4l8AAllGx06jh5zu9E="
-    },
-    "component-emitter": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-      "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
-    },
-    "component-inherit": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz",
-      "integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM="
-    },
     "compressible": {
       "version": "2.0.13",
       "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.13.tgz",
       "integrity": "sha1-DRAgq5JLL9tNYnmHXH1tq6a6p6k=",
       "requires": {
-        "mime-db": "1.33.0"
+        "mime-db": ">= 1.33.0 < 2"
       }
     },
     "concat-map": {
@@ -589,14 +526,14 @@
       "resolved": "https://registry.npmjs.org/configstore/-/configstore-1.4.0.tgz",
       "integrity": "sha1-w1eB0FAdJowlxUuLF/YkDopPsCE=",
       "requires": {
-        "graceful-fs": "4.1.11",
-        "mkdirp": "0.5.1",
-        "object-assign": "4.1.1",
-        "os-tmpdir": "1.0.2",
-        "osenv": "0.1.5",
-        "uuid": "2.0.3",
-        "write-file-atomic": "1.3.4",
-        "xdg-basedir": "2.0.0"
+        "graceful-fs": "^4.1.2",
+        "mkdirp": "^0.5.0",
+        "object-assign": "^4.0.1",
+        "os-tmpdir": "^1.0.0",
+        "osenv": "^0.1.0",
+        "uuid": "^2.0.1",
+        "write-file-atomic": "^1.1.2",
+        "xdg-basedir": "^2.0.0"
       },
       "dependencies": {
         "uuid": {
@@ -621,18 +558,13 @@
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
       "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
     },
-    "cookie": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
-      "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
-    },
     "cookies": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/cookies/-/cookies-0.7.1.tgz",
       "integrity": "sha1-fIphX1SBxhq58WyDNzG8uPZjuZs=",
       "requires": {
-        "depd": "1.1.2",
-        "keygrip": "1.0.2"
+        "depd": "~1.1.1",
+        "keygrip": "~1.0.2"
       }
     },
     "dasherize": {
@@ -700,58 +632,15 @@
       "resolved": "https://registry.npmjs.org/email-validator/-/email-validator-2.0.3.tgz",
       "integrity": "sha1-M+UNZvUmuXzXLBcgWu+ux5yKKh4="
     },
-    "engine.io": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-3.2.0.tgz",
-      "integrity": "sha512-mRbgmAtQ4GAlKwuPnnAvXXwdPhEx+jkc0OBCLrXuD/CRvwNK3AxRSnqK4FSqmAMRRHryVJP8TopOvmEaA64fKw==",
-      "requires": {
-        "accepts": "1.3.5",
-        "base64id": "1.0.0",
-        "cookie": "0.3.1",
-        "debug": "3.1.0",
-        "engine.io-parser": "2.1.2",
-        "ws": "3.3.3"
-      }
-    },
-    "engine.io-client": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.2.1.tgz",
-      "integrity": "sha512-y5AbkytWeM4jQr7m/koQLc5AxpRKC1hEVUb/s1FUAWEJq5AzJJ4NLvzuKPuxtDi5Mq755WuDvZ6Iv2rXj4PTzw==",
-      "requires": {
-        "component-emitter": "1.2.1",
-        "component-inherit": "0.0.3",
-        "debug": "3.1.0",
-        "engine.io-parser": "2.1.2",
-        "has-cors": "1.1.0",
-        "indexof": "0.0.1",
-        "parseqs": "0.0.5",
-        "parseuri": "0.0.5",
-        "ws": "3.3.3",
-        "xmlhttprequest-ssl": "1.5.5",
-        "yeast": "0.1.2"
-      }
-    },
-    "engine.io-parser": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-2.1.2.tgz",
-      "integrity": "sha512-dInLFzr80RijZ1rGpx1+56/uFoH7/7InhH3kZt+Ms6hT8tNx3NGW/WNSA/f8As1WkOfkuyb3tnRyuXGxusclMw==",
-      "requires": {
-        "after": "0.8.2",
-        "arraybuffer.slice": "0.0.7",
-        "base64-arraybuffer": "0.1.5",
-        "blob": "0.0.4",
-        "has-binary2": "1.0.2"
-      }
-    },
     "error-inject": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/error-inject/-/error-inject-1.0.0.tgz",
       "integrity": "sha1-4rPZG1Su1nLzCdlQ0VSFD6EdTzc="
     },
     "es6-promise": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
-      "integrity": "sha1-oIzd6EzNvzTQJ6FFG8kdS80ophM="
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
+      "integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ=="
     },
     "escape-html": {
       "version": "1.0.3",
@@ -783,8 +672,8 @@
       "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
       "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
       "requires": {
-        "escape-string-regexp": "1.0.5",
-        "object-assign": "4.1.1"
+        "escape-string-regexp": "^1.0.5",
+        "object-assign": "^4.1.0"
       }
     },
     "focus-trap": {
@@ -792,7 +681,7 @@
       "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-2.4.3.tgz",
       "integrity": "sha512-sT5Ip9nyAIxWq8Apt1Fdv6yTci5GotaOtO5Ro1/+F3PizttNBcCYz8j/Qze54PPFK73KUbOqh++HUCiyNPqvhA==",
       "requires": {
-        "tabbable": "1.1.2"
+        "tabbable": "^1.0.3"
       }
     },
     "for-in": {
@@ -805,7 +694,7 @@
       "resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
       "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
       "requires": {
-        "for-in": "1.0.2"
+        "for-in": "^1.0.1"
       }
     },
     "frameguard": {
@@ -828,7 +717,7 @@
       "resolved": "https://registry.npmjs.org/graphlib/-/graphlib-2.1.5.tgz",
       "integrity": "sha512-XvtbqCcw+EM5SqQrIetIKKD+uZVNQtDPD1goIg7K73RuRZtVI5rYMdcCVSHm/AS1sCBZ7vt0p5WgXouucHQaOA==",
       "requires": {
-        "lodash": "4.17.5"
+        "lodash": "^4.11.1"
       }
     },
     "has-ansi": {
@@ -836,35 +725,15 @@
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
-    },
-    "has-binary2": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-binary2/-/has-binary2-1.0.2.tgz",
-      "integrity": "sha1-6D26SfC5vk0CbSc2U1DZ8D9Uvpg=",
-      "requires": {
-        "isarray": "2.0.1"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
-          "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4="
-        }
-      }
-    },
-    "has-cors": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz",
-      "integrity": "sha1-XkdHk/fqmEPRu5nCPu9J/xJv/zk="
     },
     "hasbin": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/hasbin/-/hasbin-1.2.3.tgz",
       "integrity": "sha1-eMWSaJPIAhXCtWiuH9P8q3omlrA=",
       "requires": {
-        "async": "1.5.2"
+        "async": "~1.5"
       }
     },
     "helmet": {
@@ -923,8 +792,8 @@
       "resolved": "https://registry.npmjs.org/http-assert/-/http-assert-1.3.0.tgz",
       "integrity": "sha1-oxpc+IyHPsu1eWkH1NbxMujAHko=",
       "requires": {
-        "deep-equal": "1.0.1",
-        "http-errors": "1.6.3"
+        "deep-equal": "~1.0.1",
+        "http-errors": "~1.6.1"
       }
     },
     "http-errors": {
@@ -932,10 +801,10 @@
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "requires": {
-        "depd": "1.1.2",
+        "depd": "~1.1.2",
         "inherits": "2.0.3",
         "setprototypeof": "1.1.0",
-        "statuses": "1.5.0"
+        "statuses": ">= 1.4.0 < 2"
       }
     },
     "iconv-lite": {
@@ -943,7 +812,7 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.21.tgz",
       "integrity": "sha512-En5V9za5mBt2oUA03WGD3TwDv0MKAruqsuxstbMUZaj9W9k/m1CV/9py3l0L5kw9Bln8fdHQmzHSYtvpvTLpKw==",
       "requires": {
-        "safer-buffer": "2.1.2"
+        "safer-buffer": "^2.1.0"
       }
     },
     "ienoopen": {
@@ -955,11 +824,6 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
-    },
-    "indexof": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
-      "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10="
     },
     "inherits": {
       "version": "2.0.3",
@@ -976,19 +840,19 @@
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-1.0.3.tgz",
       "integrity": "sha1-6+OglIVxvMRszMvi+bzsJR6YS9A=",
       "requires": {
-        "ansi-escapes": "1.4.0",
-        "chalk": "1.1.3",
-        "cli-cursor": "1.0.2",
-        "cli-width": "2.2.0",
-        "figures": "1.7.0",
-        "lodash": "4.17.5",
+        "ansi-escapes": "^1.1.0",
+        "chalk": "^1.0.0",
+        "cli-cursor": "^1.0.1",
+        "cli-width": "^2.0.0",
+        "figures": "^1.3.5",
+        "lodash": "^4.3.0",
         "mute-stream": "0.0.6",
-        "pinkie-promise": "2.0.1",
-        "run-async": "2.3.0",
-        "rx": "4.1.0",
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1",
-        "through": "2.3.8"
+        "pinkie-promise": "^2.0.0",
+        "run-async": "^2.2.0",
+        "rx": "^4.1.0",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.0",
+        "through": "^2.3.6"
       }
     },
     "is-buffer": {
@@ -1006,7 +870,7 @@
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
     },
     "is-generator-function": {
@@ -1019,7 +883,7 @@
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
       "requires": {
-        "isobject": "3.0.1"
+        "isobject": "^3.0.1"
       }
     },
     "is-promise": {
@@ -1042,8 +906,8 @@
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
       "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
       "requires": {
-        "argparse": "1.0.10",
-        "esprima": "4.0.0"
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
       }
     },
     "keygrip": {
@@ -1056,64 +920,54 @@
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "requires": {
-        "is-buffer": "1.1.6"
+        "is-buffer": "^1.1.5"
       }
     },
     "koa": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/koa/-/koa-2.5.0.tgz",
-      "integrity": "sha512-UkrbMW2mRNfoW/4I20knJEjtPAWCV3Iw6f4XdnPWjHsCN8iTeSh0eSutrYdL0fGF/G9on2eQ30EEQif0MarGJA==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/koa/-/koa-2.5.1.tgz",
+      "integrity": "sha512-cchwbMeG2dv3E2xTAmheDAuvR53tPgJZN/Hf1h7bTzJLSPcFZp8/t5+bNKJ6GaQZoydhZQ+1GNruhKdj3lIrug==",
       "requires": {
-        "accepts": "1.3.5",
-        "content-disposition": "0.5.2",
-        "content-type": "1.0.4",
-        "cookies": "0.7.1",
-        "debug": "3.1.0",
-        "delegates": "1.0.0",
-        "depd": "1.1.2",
-        "destroy": "1.0.4",
-        "error-inject": "1.0.0",
-        "escape-html": "1.0.3",
-        "fresh": "0.5.2",
-        "http-assert": "1.3.0",
-        "http-errors": "1.6.3",
-        "is-generator-function": "1.0.7",
-        "koa-compose": "4.0.0",
-        "koa-convert": "1.2.0",
-        "koa-is-json": "1.0.0",
-        "mime-types": "2.1.18",
-        "on-finished": "2.3.0",
+        "accepts": "^1.2.2",
+        "content-disposition": "~0.5.0",
+        "content-type": "^1.0.0",
+        "cookies": "~0.7.0",
+        "debug": "*",
+        "delegates": "^1.0.0",
+        "depd": "^1.1.0",
+        "destroy": "^1.0.3",
+        "error-inject": "~1.0.0",
+        "escape-html": "~1.0.1",
+        "fresh": "^0.5.2",
+        "http-assert": "^1.1.0",
+        "http-errors": "^1.2.8",
+        "is-generator-function": "^1.0.3",
+        "koa-compose": "^4.0.0",
+        "koa-convert": "^1.2.0",
+        "koa-is-json": "^1.0.0",
+        "mime-types": "^2.0.7",
+        "on-finished": "^2.1.0",
         "only": "0.0.2",
-        "parseurl": "1.3.2",
-        "statuses": "1.5.0",
-        "type-is": "1.6.16",
-        "vary": "1.1.2"
-      },
-      "dependencies": {
-        "koa-compose": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/koa-compose/-/koa-compose-4.0.0.tgz",
-          "integrity": "sha1-KAClE9nDYe8NY4UrA45Pby1adzw="
-        }
+        "parseurl": "^1.3.0",
+        "statuses": "^1.2.0",
+        "type-is": "^1.5.5",
+        "vary": "^1.0.0"
       }
     },
     "koa-compose": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/koa-compose/-/koa-compose-3.2.1.tgz",
-      "integrity": "sha1-qFzLQLfZhtjlo0Wzoazo6rz1Tec=",
-      "requires": {
-        "any-promise": "1.3.0"
-      }
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/koa-compose/-/koa-compose-4.0.0.tgz",
+      "integrity": "sha1-KAClE9nDYe8NY4UrA45Pby1adzw="
     },
     "koa-compress": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/koa-compress/-/koa-compress-3.0.0.tgz",
       "integrity": "sha512-xol+LkNB1mozKJkB5Kj6nYXbJXhkLkZlXl9BsGBPjujVfZ8MsIXwU4GHRTT7TlSfUcl2DU3JtC+j6wOWcovfuQ==",
       "requires": {
-        "bytes": "3.0.0",
-        "compressible": "2.0.13",
-        "koa-is-json": "1.0.0",
-        "statuses": "1.5.0"
+        "bytes": "^3.0.0",
+        "compressible": "^2.0.0",
+        "koa-is-json": "^1.0.0",
+        "statuses": "^1.0.0"
       }
     },
     "koa-convert": {
@@ -1121,8 +975,18 @@
       "resolved": "https://registry.npmjs.org/koa-convert/-/koa-convert-1.2.0.tgz",
       "integrity": "sha1-2kCHXfSd4FOQmNFwC1CCDOvNIdA=",
       "requires": {
-        "co": "4.6.0",
-        "koa-compose": "3.2.1"
+        "co": "^4.6.0",
+        "koa-compose": "^3.0.0"
+      },
+      "dependencies": {
+        "koa-compose": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/koa-compose/-/koa-compose-3.2.1.tgz",
+          "integrity": "sha1-qFzLQLfZhtjlo0Wzoazo6rz1Tec=",
+          "requires": {
+            "any-promise": "^1.1.0"
+          }
+        }
       }
     },
     "koa-helmet": {
@@ -1130,7 +994,7 @@
       "resolved": "https://registry.npmjs.org/koa-helmet/-/koa-helmet-4.0.0.tgz",
       "integrity": "sha512-WBimFdr0B8PVvDqdFCmx1eJ08jxvyIzNit8qFBxWn6rY/QjU+VLgc5JGnc757uYhZc2TgPirctGBG6P7yC0TEw==",
       "requires": {
-        "helmet": "3.12.0"
+        "helmet": "^3.12.0"
       }
     },
     "koa-is-json": {
@@ -1143,8 +1007,8 @@
       "resolved": "https://registry.npmjs.org/koa-mount/-/koa-mount-3.0.0.tgz",
       "integrity": "sha1-CMqzuD0xRC7Yt+dcVLGr65IuwZc=",
       "requires": {
-        "debug": "2.6.9",
-        "koa-compose": "3.2.1"
+        "debug": "^2.6.1",
+        "koa-compose": "^3.2.1"
       },
       "dependencies": {
         "debug": {
@@ -1153,6 +1017,14 @@
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "requires": {
             "ms": "2.0.0"
+          }
+        },
+        "koa-compose": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/koa-compose/-/koa-compose-3.2.1.tgz",
+          "integrity": "sha1-qFzLQLfZhtjlo0Wzoazo6rz1Tec=",
+          "requires": {
+            "any-promise": "^1.1.0"
           }
         },
         "ms": {
@@ -1167,12 +1039,22 @@
       "resolved": "https://registry.npmjs.org/koa-router/-/koa-router-7.4.0.tgz",
       "integrity": "sha512-IWhaDXeAnfDBEpWS6hkGdZ1ablgr6Q6pGdXCyK38RbzuH4LkUOpPqPw+3f8l8aTDrQmBQ7xJc0bs2yV4dzcO+g==",
       "requires": {
-        "debug": "3.1.0",
-        "http-errors": "1.6.3",
-        "koa-compose": "3.2.1",
-        "methods": "1.1.2",
-        "path-to-regexp": "1.7.0",
-        "urijs": "1.19.1"
+        "debug": "^3.1.0",
+        "http-errors": "^1.3.1",
+        "koa-compose": "^3.0.0",
+        "methods": "^1.0.1",
+        "path-to-regexp": "^1.1.1",
+        "urijs": "^1.19.0"
+      },
+      "dependencies": {
+        "koa-compose": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/koa-compose/-/koa-compose-3.2.1.tgz",
+          "integrity": "sha1-qFzLQLfZhtjlo0Wzoazo6rz1Tec=",
+          "requires": {
+            "any-promise": "^1.1.0"
+          }
+        }
       }
     },
     "koa-send": {
@@ -1180,10 +1062,10 @@
       "resolved": "https://registry.npmjs.org/koa-send/-/koa-send-4.1.3.tgz",
       "integrity": "sha512-3UetMBdaXSiw24qM2Mx5mKmxLKw5ZTPRjACjfhK6Haca55RKm9hr/uHDrkrxhSl5/S1CKI/RivZVIopiatZuTA==",
       "requires": {
-        "debug": "2.6.9",
-        "http-errors": "1.6.3",
-        "mz": "2.7.0",
-        "resolve-path": "1.4.0"
+        "debug": "^2.6.3",
+        "http-errors": "^1.6.1",
+        "mz": "^2.6.0",
+        "resolve-path": "^1.4.0"
       },
       "dependencies": {
         "debug": {
@@ -1206,8 +1088,8 @@
       "resolved": "https://registry.npmjs.org/koa-static/-/koa-static-4.0.2.tgz",
       "integrity": "sha512-tKaDVRz3lgPfdFhiYe3jNQnlSVf0AnOv7ZJqQYHkT4/kPan6b59HSmotNm2Qjl2JDlCli4xKVOMHui+fZLwNRg==",
       "requires": {
-        "debug": "2.6.9",
-        "koa-send": "4.1.3"
+        "debug": "^2.6.8",
+        "koa-send": "^4.1.0"
       },
       "dependencies": {
         "debug": {
@@ -1231,9 +1113,9 @@
       "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4="
     },
     "lodash": {
-      "version": "4.17.5",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-      "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+      "version": "4.17.10",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
     },
     "lodash.assign": {
       "version": "4.2.0",
@@ -1280,8 +1162,8 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.2.tgz",
       "integrity": "sha512-wgeVXhrDwAWnIF/yZARsFnMBtdFXOg1b8RIrhilp+0iDYN4mdQcNZElDZ0e4B64BhaxeQ5zN7PMyvu7we1kPeQ==",
       "requires": {
-        "pseudomap": "1.0.2",
-        "yallist": "2.1.2"
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
       }
     },
     "material-components-web": {
@@ -1289,36 +1171,36 @@
       "resolved": "https://registry.npmjs.org/material-components-web/-/material-components-web-0.29.0.tgz",
       "integrity": "sha512-c3YIzvmKQGGXdl+qbdrvlbHyKBGlL2/rOd8IPZBSu/gPXxQpkc6J4+xoSheQ3bfgYdGvvAGeBRGl0ePt0q6kEg==",
       "requires": {
-        "@material/animation": "0.25.0",
-        "@material/auto-init": "0.29.0",
-        "@material/base": "0.29.0",
-        "@material/button": "0.29.0",
-        "@material/card": "0.29.0",
-        "@material/checkbox": "0.29.0",
-        "@material/dialog": "0.29.0",
-        "@material/drawer": "0.29.0",
-        "@material/elevation": "0.28.0",
-        "@material/fab": "0.29.0",
-        "@material/form-field": "0.29.0",
-        "@material/grid-list": "0.29.0",
-        "@material/icon-toggle": "0.29.0",
-        "@material/layout-grid": "0.24.0",
-        "@material/linear-progress": "0.29.0",
-        "@material/list": "0.29.0",
-        "@material/menu": "0.29.0",
-        "@material/radio": "0.29.0",
-        "@material/ripple": "0.29.0",
-        "@material/rtl": "0.29.0",
-        "@material/select": "0.29.0",
-        "@material/selection-control": "0.29.0",
-        "@material/slider": "0.29.0",
-        "@material/snackbar": "0.29.0",
-        "@material/switch": "0.29.0",
-        "@material/tabs": "0.29.0",
-        "@material/textfield": "0.29.0",
-        "@material/theme": "0.29.0",
-        "@material/toolbar": "0.29.0",
-        "@material/typography": "0.28.0"
+        "@material/animation": "^0.25.0",
+        "@material/auto-init": "^0.29.0",
+        "@material/base": "^0.29.0",
+        "@material/button": "^0.29.0",
+        "@material/card": "^0.29.0",
+        "@material/checkbox": "^0.29.0",
+        "@material/dialog": "^0.29.0",
+        "@material/drawer": "^0.29.0",
+        "@material/elevation": "^0.28.0",
+        "@material/fab": "^0.29.0",
+        "@material/form-field": "^0.29.0",
+        "@material/grid-list": "^0.29.0",
+        "@material/icon-toggle": "^0.29.0",
+        "@material/layout-grid": "^0.24.0",
+        "@material/linear-progress": "^0.29.0",
+        "@material/list": "^0.29.0",
+        "@material/menu": "^0.29.0",
+        "@material/radio": "^0.29.0",
+        "@material/ripple": "^0.29.0",
+        "@material/rtl": "^0.29.0",
+        "@material/select": "^0.29.0",
+        "@material/selection-control": "^0.29.0",
+        "@material/slider": "^0.29.0",
+        "@material/snackbar": "^0.29.0",
+        "@material/switch": "^0.29.0",
+        "@material/tabs": "^0.29.0",
+        "@material/textfield": "^0.29.0",
+        "@material/theme": "^0.29.0",
+        "@material/toolbar": "^0.29.0",
+        "@material/typography": "^0.28.0"
       }
     },
     "media-typer": {
@@ -1341,7 +1223,7 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
       "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
       "requires": {
-        "mime-db": "1.33.0"
+        "mime-db": "~1.33.0"
       }
     },
     "minimatch": {
@@ -1349,7 +1231,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
-        "brace-expansion": "1.1.11"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -1362,8 +1244,8 @@
       "resolved": "https://registry.npmjs.org/mixin-object/-/mixin-object-2.0.1.tgz",
       "integrity": "sha1-T7lJRB2rGCVA8f4DW6YOGUel5X4=",
       "requires": {
-        "for-in": "0.1.8",
-        "is-extendable": "0.1.1"
+        "for-in": "^0.1.3",
+        "is-extendable": "^0.1.1"
       },
       "dependencies": {
         "for-in": {
@@ -1396,9 +1278,9 @@
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
       "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
       "requires": {
-        "any-promise": "1.3.0",
-        "object-assign": "4.1.1",
-        "thenify-all": "1.6.0"
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
       }
     },
     "nan": {
@@ -1411,9 +1293,9 @@
       "resolved": "https://registry.npmjs.org/nconf/-/nconf-0.7.2.tgz",
       "integrity": "sha1-oF/fItwBw3jdXE3yfy3JC5qouwA=",
       "requires": {
-        "async": "0.9.2",
-        "ini": "1.3.5",
-        "yargs": "3.15.0"
+        "async": "~0.9.0",
+        "ini": "1.x.x",
+        "yargs": "~3.15.0"
       },
       "dependencies": {
         "async": {
@@ -1424,13 +1306,13 @@
       }
     },
     "needle": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/needle/-/needle-2.2.0.tgz",
-      "integrity": "sha512-eFagy6c+TYayorXw/qtAdSvaUpEbBsDwDyxYFgLZ0lTojfH7K+OdBqAF7TAFwDokJaGpubpSGG0wO3iC0XPi8w==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-2.2.1.tgz",
+      "integrity": "sha512-t/ZswCM9JTWjAdXS9VpvqhI2Ct2sL2MdY4fUXqGJaGBk13ge99ObqRksRTbBE56K+wxUXwwfZYOuZHifFW9q+Q==",
       "requires": {
-        "debug": "2.6.9",
-        "iconv-lite": "0.4.21",
-        "sax": "1.2.4"
+        "debug": "^2.1.2",
+        "iconv-lite": "^0.4.4",
+        "sax": "^1.2.4"
       },
       "dependencies": {
         "debug": {
@@ -1468,11 +1350,6 @@
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
-    "object-component": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz",
-      "integrity": "sha1-8MaapQ78lbhmwYb0AKM3acsvEpE="
-    },
     "on-finished": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
@@ -1506,8 +1383,8 @@
       "resolved": "https://registry.npmjs.org/os-name/-/os-name-1.0.3.tgz",
       "integrity": "sha1-GzefZINa98Wn9JizV8uVIVwVnt8=",
       "requires": {
-        "osx-release": "1.1.0",
-        "win-release": "1.1.1"
+        "osx-release": "^1.0.0",
+        "win-release": "^1.0.0"
       }
     },
     "os-tmpdir": {
@@ -1520,8 +1397,8 @@
       "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
       "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
       "requires": {
-        "os-homedir": "1.0.2",
-        "os-tmpdir": "1.0.2"
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.0"
       }
     },
     "osx-release": {
@@ -1529,7 +1406,7 @@
       "resolved": "https://registry.npmjs.org/osx-release/-/osx-release-1.1.0.tgz",
       "integrity": "sha1-8heRGigTaUmvG/kwiyQeJzfTzWw=",
       "requires": {
-        "minimist": "1.2.0"
+        "minimist": "^1.1.0"
       },
       "dependencies": {
         "minimist": {
@@ -1537,22 +1414,6 @@
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         }
-      }
-    },
-    "parseqs": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.5.tgz",
-      "integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=",
-      "requires": {
-        "better-assert": "1.0.2"
-      }
-    },
-    "parseuri": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.5.tgz",
-      "integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=",
-      "requires": {
-        "better-assert": "1.0.2"
       }
     },
     "parseurl": {
@@ -1583,7 +1444,7 @@
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "requires": {
-        "pinkie": "2.0.4"
+        "pinkie": "^2.0.0"
       }
     },
     "platform": {
@@ -1596,7 +1457,7 @@
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
       "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
       "requires": {
-        "asap": "2.0.6"
+        "asap": "~2.0.3"
       }
     },
     "proxy-from-env": {
@@ -1642,7 +1503,7 @@
       "resolved": "https://registry.npmjs.org/resolve-path/-/resolve-path-1.4.0.tgz",
       "integrity": "sha1-xL2p9e+y/OZSR4c6s2u02DT+Fvc=",
       "requires": {
-        "http-errors": "1.6.3",
+        "http-errors": "~1.6.2",
         "path-is-absolute": "1.0.1"
       }
     },
@@ -1651,8 +1512,8 @@
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
       "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
       "requires": {
-        "exit-hook": "1.1.1",
-        "onetime": "1.1.0"
+        "exit-hook": "^1.0.0",
+        "onetime": "^1.0.0"
       }
     },
     "right-align": {
@@ -1660,7 +1521,7 @@
       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
       "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
       "requires": {
-        "align-text": "0.1.4"
+        "align-text": "^0.1.1"
       }
     },
     "rpio": {
@@ -1668,8 +1529,8 @@
       "resolved": "https://registry.npmjs.org/rpio/-/rpio-0.9.21.tgz",
       "integrity": "sha512-I2SZcIFGIEXwr3el7hiREATw/FFBTVANCC+Avahy5gKODQ7g7x5qIFeuIpsQGR4gQqqRsHJc7507UluNYlnweg==",
       "requires": {
-        "bindings": "1.3.0",
-        "nan": "2.10.0"
+        "bindings": "*",
+        "nan": "*"
       }
     },
     "run-async": {
@@ -1677,18 +1538,13 @@
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
       "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
       "requires": {
-        "is-promise": "2.1.0"
+        "is-promise": "^2.1.0"
       }
     },
     "rx": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
       "integrity": "sha1-pfE/957zt0D+MKqAP7CfmIBdR4I="
-    },
-    "safe-buffer": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
     },
     "safer-buffer": {
       "version": "2.1.2",
@@ -1715,10 +1571,10 @@
       "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-0.1.2.tgz",
       "integrity": "sha1-WQnodLp3EG1zrEFM/sH/yofZcGA=",
       "requires": {
-        "is-extendable": "0.1.1",
-        "kind-of": "2.0.1",
-        "lazy-cache": "0.2.7",
-        "mixin-object": "2.0.1"
+        "is-extendable": "^0.1.1",
+        "kind-of": "^2.0.1",
+        "lazy-cache": "^0.2.3",
+        "mixin-object": "^2.0.1"
       },
       "dependencies": {
         "kind-of": {
@@ -1726,7 +1582,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
           "integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.0.2"
           }
         },
         "lazy-cache": {
@@ -1742,24 +1598,23 @@
       "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc="
     },
     "snyk": {
-      "version": "1.73.0",
-      "resolved": "https://registry.npmjs.org/snyk/-/snyk-1.73.0.tgz",
-      "integrity": "sha1-vDi8Xoj6WmPsJAmfix63TpxkOXg=",
+      "version": "1.74.0",
+      "resolved": "https://registry.npmjs.org/snyk/-/snyk-1.74.0.tgz",
+      "integrity": "sha1-6iTp0LzrkMB6fbkzIi8lOcUty68=",
       "requires": {
-        "abbrev": "1.1.1",
-        "ansi-escapes": "1.4.0",
-        "chalk": "1.1.3",
-        "configstore": "1.4.0",
-        "debug": "3.1.0",
-        "es6-promise": "3.3.1",
-        "hasbin": "1.2.3",
+        "abbrev": "^1.0.7",
+        "ansi-escapes": "^1.3.0",
+        "chalk": "^1.1.0",
+        "configstore": "^1.2.0",
+        "debug": "^3.1.0",
+        "hasbin": "^1.2.3",
         "inquirer": "1.0.3",
-        "needle": "2.2.0",
-        "open": "0.0.5",
-        "os-name": "1.0.3",
-        "proxy-from-env": "1.0.0",
-        "recursive-readdir": "2.2.2",
-        "semver": "5.5.0",
+        "needle": "^2.0.1",
+        "open": "^0.0.5",
+        "os-name": "^1.0.3",
+        "proxy-from-env": "^1.0.0",
+        "recursive-readdir": "^2.2.1",
+        "semver": "^5.1.0",
         "snyk-config": "1.0.1",
         "snyk-go-plugin": "1.4.6",
         "snyk-gradle-plugin": "1.2.0",
@@ -1767,18 +1622,18 @@
         "snyk-mvn-plugin": "1.1.1",
         "snyk-nuget-plugin": "1.3.9",
         "snyk-php-plugin": "1.3.2",
-        "snyk-policy": "1.11.0",
+        "snyk-policy": "^1.10.2",
         "snyk-python-plugin": "1.5.8",
         "snyk-resolve": "1.0.0",
         "snyk-resolve-deps": "2.0.0",
         "snyk-sbt-plugin": "1.2.5",
-        "snyk-tree": "1.0.0",
-        "snyk-try-require": "1.2.0",
-        "tempfile": "1.1.1",
-        "then-fs": "2.0.0",
+        "snyk-tree": "^1.0.0",
+        "snyk-try-require": "^1.2.0",
+        "tempfile": "^1.1.1",
+        "then-fs": "^2.0.0",
         "undefsafe": "0.0.3",
-        "url": "0.11.0",
-        "uuid": "3.2.1"
+        "url": "^0.11.0",
+        "uuid": "^3.0.1"
       }
     },
     "snyk-config": {
@@ -1786,9 +1641,9 @@
       "resolved": "https://registry.npmjs.org/snyk-config/-/snyk-config-1.0.1.tgz",
       "integrity": "sha1-8nrsJJiyQCescZIUAmUhWRERUI8=",
       "requires": {
-        "debug": "2.6.9",
-        "nconf": "0.7.2",
-        "path-is-absolute": "1.0.1"
+        "debug": "^2.2.0",
+        "nconf": "^0.7.2",
+        "path-is-absolute": "^1.0.0"
       },
       "dependencies": {
         "debug": {
@@ -1811,8 +1666,8 @@
       "resolved": "https://registry.npmjs.org/snyk-go-plugin/-/snyk-go-plugin-1.4.6.tgz",
       "integrity": "sha512-Fnl5UWjklZzXN05MsWThM+8jW71LAD0k/bMt8Gqbnb0EdmOdyopyxfeTw2K6yXxyBiiVSJE0De+2Enak4zgBwA==",
       "requires": {
-        "graphlib": "2.1.5",
-        "toml": "2.3.3"
+        "graphlib": "^2.1.1",
+        "toml": "^2.3.2"
       }
     },
     "snyk-gradle-plugin": {
@@ -1820,7 +1675,7 @@
       "resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-1.2.0.tgz",
       "integrity": "sha512-FucMRR+Rc6LBaSIYxiBl+jvb7R00SgA0QfMT+RGxLIZlDk1lagvA/jIkv+mRadwHVSV/ShIFSZLmS7agfPclVg==",
       "requires": {
-        "clone-deep": "0.3.0"
+        "clone-deep": "^0.3.0"
       }
     },
     "snyk-module": {
@@ -1828,8 +1683,8 @@
       "resolved": "https://registry.npmjs.org/snyk-module/-/snyk-module-1.8.1.tgz",
       "integrity": "sha1-MdUID7HA39b6hWfdNKUj/QK/H8o=",
       "requires": {
-        "debug": "2.6.9",
-        "hosted-git-info": "2.6.0"
+        "debug": "^2.2.0",
+        "hosted-git-info": "^2.1.4"
       },
       "dependencies": {
         "debug": {
@@ -1857,17 +1712,10 @@
       "resolved": "https://registry.npmjs.org/snyk-nuget-plugin/-/snyk-nuget-plugin-1.3.9.tgz",
       "integrity": "sha512-F38Amr8AxbalFfUmjLM+57P2Gq2vUh9dWsP7oE2DPXO/f7tW00jwyWhJ5D39Zx+elBoXDxWYvAp14IJnxV18Ag==",
       "requires": {
-        "debug": "3.1.0",
-        "es6-promise": "4.2.4",
-        "xml2js": "0.4.19",
-        "zip": "1.2.0"
-      },
-      "dependencies": {
-        "es6-promise": {
-          "version": "4.2.4",
-          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
-          "integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ=="
-        }
+        "debug": "^3.1.0",
+        "es6-promise": "^4.1.1",
+        "xml2js": "^0.4.17",
+        "zip": "^1.2.0"
       }
     },
     "snyk-php-plugin": {
@@ -1875,7 +1723,7 @@
       "resolved": "https://registry.npmjs.org/snyk-php-plugin/-/snyk-php-plugin-1.3.2.tgz",
       "integrity": "sha512-EVN5ilP2PJ5EEBWUvSjzI1kHTRyJxqCQXm5Bb2Kkl4z1cNCFO9ScxjwUDO7cJmQCDQUhHGflDd611ToWmlEYnQ==",
       "requires": {
-        "debug": "3.1.0"
+        "debug": "^3.1.0"
       }
     },
     "snyk-policy": {
@@ -1883,16 +1731,16 @@
       "resolved": "https://registry.npmjs.org/snyk-policy/-/snyk-policy-1.11.0.tgz",
       "integrity": "sha1-mhyQjv7RmbrV1047dDkyCZRAYJI=",
       "requires": {
-        "debug": "2.6.9",
-        "email-validator": "2.0.3",
-        "es6-promise": "3.3.1",
-        "js-yaml": "3.11.0",
-        "lodash.clonedeep": "4.5.0",
-        "semver": "5.5.0",
-        "snyk-module": "1.8.1",
-        "snyk-resolve": "1.0.0",
-        "snyk-try-require": "1.2.0",
-        "then-fs": "2.0.0"
+        "debug": "^2.2.0",
+        "email-validator": "^2.0.3",
+        "es6-promise": "^3.1.2",
+        "js-yaml": "^3.5.3",
+        "lodash.clonedeep": "^4.3.1",
+        "semver": "^5.1.0",
+        "snyk-module": "^1.8.1",
+        "snyk-resolve": "^1.0.0",
+        "snyk-try-require": "^1.1.1",
+        "then-fs": "^2.0.0"
       },
       "dependencies": {
         "debug": {
@@ -1902,6 +1750,11 @@
           "requires": {
             "ms": "2.0.0"
           }
+        },
+        "es6-promise": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
+          "integrity": "sha1-oIzd6EzNvzTQJ6FFG8kdS80ophM="
         },
         "ms": {
           "version": "2.0.0",
@@ -1920,8 +1773,8 @@
       "resolved": "https://registry.npmjs.org/snyk-resolve/-/snyk-resolve-1.0.0.tgz",
       "integrity": "sha1-u+kZbTf1fDklHmvnXM3Vsgl+maI=",
       "requires": {
-        "debug": "2.6.9",
-        "then-fs": "2.0.0"
+        "debug": "^2.2.0",
+        "then-fs": "^2.0.0"
       },
       "dependencies": {
         "debug": {
@@ -1944,23 +1797,23 @@
       "resolved": "https://registry.npmjs.org/snyk-resolve-deps/-/snyk-resolve-deps-2.0.0.tgz",
       "integrity": "sha1-k9BYO+J+aQP1YMH3fqj34MUoadE=",
       "requires": {
-        "abbrev": "1.1.1",
-        "ansicolors": "0.3.2",
-        "debug": "2.6.9",
-        "es6-promise": "3.3.1",
-        "lodash.assign": "4.2.0",
-        "lodash.assignin": "4.2.0",
-        "lodash.flatten": "4.4.0",
-        "lodash.get": "4.4.2",
-        "lodash.set": "4.3.2",
-        "lru-cache": "4.1.2",
-        "minimist": "1.2.0",
-        "semver": "5.5.0",
-        "snyk-module": "1.8.1",
-        "snyk-resolve": "1.0.0",
-        "snyk-tree": "1.0.0",
-        "snyk-try-require": "1.2.0",
-        "then-fs": "2.0.0"
+        "abbrev": "^1.0.7",
+        "ansicolors": "^0.3.2",
+        "debug": "^2.2.0",
+        "es6-promise": "^3.0.2",
+        "lodash.assign": "^4.2.0",
+        "lodash.assignin": "^4.2.0",
+        "lodash.flatten": "^4.4.0",
+        "lodash.get": "^4.4.2",
+        "lodash.set": "^4.3.2",
+        "lru-cache": "^4.0.0",
+        "minimist": "^1.2.0",
+        "semver": "^5.1.0",
+        "snyk-module": "^1.6.0",
+        "snyk-resolve": "^1.0.0",
+        "snyk-tree": "^1.0.0",
+        "snyk-try-require": "^1.1.1",
+        "then-fs": "^2.0.0"
       },
       "dependencies": {
         "debug": {
@@ -1970,6 +1823,11 @@
           "requires": {
             "ms": "2.0.0"
           }
+        },
+        "es6-promise": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
+          "integrity": "sha1-oIzd6EzNvzTQJ6FFG8kdS80ophM="
         },
         "minimist": {
           "version": "1.2.0",
@@ -1988,7 +1846,7 @@
       "resolved": "https://registry.npmjs.org/snyk-sbt-plugin/-/snyk-sbt-plugin-1.2.5.tgz",
       "integrity": "sha512-6D981zAdFYatBLNwp7J5Vl5wZFieBlwKj1Ans9uZ5BZZfg4mjIX/62tfADmJEbHijvnN+i7N8cNQRvVOyLo2UA==",
       "requires": {
-        "debug": "2.6.9"
+        "debug": "^2.2.0"
       },
       "dependencies": {
         "debug": {
@@ -2011,7 +1869,7 @@
       "resolved": "https://registry.npmjs.org/snyk-tree/-/snyk-tree-1.0.0.tgz",
       "integrity": "sha1-D7cxdtvzLngvGRAClBYESPkRHMg=",
       "requires": {
-        "archy": "1.0.0"
+        "archy": "^1.0.0"
       }
     },
     "snyk-try-require": {
@@ -2019,11 +1877,11 @@
       "resolved": "https://registry.npmjs.org/snyk-try-require/-/snyk-try-require-1.2.0.tgz",
       "integrity": "sha1-MPwrEcBwZFke41eAyCa+kTEvIUQ=",
       "requires": {
-        "debug": "2.6.9",
-        "es6-promise": "3.3.1",
-        "lodash.clonedeep": "4.5.0",
-        "lru-cache": "4.1.2",
-        "then-fs": "2.0.0"
+        "debug": "^2.2.0",
+        "es6-promise": "^3.1.2",
+        "lodash.clonedeep": "^4.3.0",
+        "lru-cache": "^4.0.0",
+        "then-fs": "^2.0.0"
       },
       "dependencies": {
         "debug": {
@@ -2034,66 +1892,15 @@
             "ms": "2.0.0"
           }
         },
+        "es6-promise": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
+          "integrity": "sha1-oIzd6EzNvzTQJ6FFG8kdS80ophM="
+        },
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        }
-      }
-    },
-    "socket.io": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-2.1.0.tgz",
-      "integrity": "sha512-KS+3CNWWNtLbVN5j0/B+1hjxRzey+oTK6ejpAOoxMZis6aXeB8cUtfuvjHl97tuZx+t/qD/VyqFMjuzu2Js6uQ==",
-      "requires": {
-        "debug": "3.1.0",
-        "engine.io": "3.2.0",
-        "has-binary2": "1.0.2",
-        "socket.io-adapter": "1.1.1",
-        "socket.io-client": "2.1.0",
-        "socket.io-parser": "3.2.0"
-      }
-    },
-    "socket.io-adapter": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-1.1.1.tgz",
-      "integrity": "sha1-KoBeihTWNyEk3ZFZrUUC+MsH8Gs="
-    },
-    "socket.io-client": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.1.0.tgz",
-      "integrity": "sha512-TvKPpL0cBON5LduQfR8Rxrr+ktj70bLXGvqHCL3er5avBXruB3gpnbaud5ikFYVfANH1gCABAvo0qN8Axpg2ew==",
-      "requires": {
-        "backo2": "1.0.2",
-        "base64-arraybuffer": "0.1.5",
-        "component-bind": "1.0.0",
-        "component-emitter": "1.2.1",
-        "debug": "3.1.0",
-        "engine.io-client": "3.2.1",
-        "has-binary2": "1.0.2",
-        "has-cors": "1.1.0",
-        "indexof": "0.0.1",
-        "object-component": "0.0.3",
-        "parseqs": "0.0.5",
-        "parseuri": "0.0.5",
-        "socket.io-parser": "3.2.0",
-        "to-array": "0.1.4"
-      }
-    },
-    "socket.io-parser": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.2.0.tgz",
-      "integrity": "sha512-FYiBx7rc/KORMJlgsXysflWx/RIvtqZbyGLlHZvjfmPTPeuD/I8MaW7cfFrj5tRltICJdgwflhfZ3NVVbVLFQA==",
-      "requires": {
-        "component-emitter": "1.2.1",
-        "debug": "3.1.0",
-        "isarray": "2.0.1"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
-          "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4="
         }
       }
     },
@@ -2112,9 +1919,9 @@
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "requires": {
-        "code-point-at": "1.1.0",
-        "is-fullwidth-code-point": "1.0.0",
-        "strip-ansi": "3.0.1"
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "strip-ansi": "^3.0.0"
       }
     },
     "strip-ansi": {
@@ -2122,7 +1929,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "supports-color": {
@@ -2140,8 +1947,8 @@
       "resolved": "https://registry.npmjs.org/tempfile/-/tempfile-1.1.1.tgz",
       "integrity": "sha1-W8xOrsxKsscH2LwR2ZzMmiyyh/I=",
       "requires": {
-        "os-tmpdir": "1.0.2",
-        "uuid": "2.0.3"
+        "os-tmpdir": "^1.0.0",
+        "uuid": "^2.0.1"
       },
       "dependencies": {
         "uuid": {
@@ -2156,7 +1963,7 @@
       "resolved": "https://registry.npmjs.org/then-fs/-/then-fs-2.0.0.tgz",
       "integrity": "sha1-cveS3Z0xcFqRrhnr/Piz+WjIHaI=",
       "requires": {
-        "promise": "7.3.1"
+        "promise": ">=3.2 <8"
       }
     },
     "thenify": {
@@ -2164,7 +1971,7 @@
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.0.tgz",
       "integrity": "sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=",
       "requires": {
-        "any-promise": "1.3.0"
+        "any-promise": "^1.0.0"
       }
     },
     "thenify-all": {
@@ -2172,18 +1979,13 @@
       "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
       "integrity": "sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=",
       "requires": {
-        "thenify": "3.3.0"
+        "thenify": ">= 3.1.0 < 4"
       }
     },
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
-    },
-    "to-array": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/to-array/-/to-array-0.1.4.tgz",
-      "integrity": "sha1-F+bBH3PdTz10zaek/zI46a2b+JA="
     },
     "to-utf8": {
       "version": "0.0.1",
@@ -2201,13 +2003,8 @@
       "integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
       "requires": {
         "media-typer": "0.3.0",
-        "mime-types": "2.1.18"
+        "mime-types": "~2.1.18"
       }
-    },
-    "ultron": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
-      "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og=="
     },
     "undefsafe": {
       "version": "0.0.3",
@@ -2243,7 +2040,7 @@
       "resolved": "https://registry.npmjs.org/win-release/-/win-release-1.1.1.tgz",
       "integrity": "sha1-X6VeAr58qTTt/BJmVjLoSbcuUgk=",
       "requires": {
-        "semver": "5.5.0"
+        "semver": "^5.0.1"
       }
     },
     "window-size": {
@@ -2261,19 +2058,9 @@
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
       "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
       "requires": {
-        "graceful-fs": "4.1.11",
-        "imurmurhash": "0.1.4",
-        "slide": "1.1.6"
-      }
-    },
-    "ws": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
-      "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
-      "requires": {
-        "async-limiter": "1.0.0",
-        "safe-buffer": "5.1.1",
-        "ultron": "1.1.1"
+        "graceful-fs": "^4.1.11",
+        "imurmurhash": "^0.1.4",
+        "slide": "^1.1.5"
       }
     },
     "x-xss-protection": {
@@ -2286,7 +2073,7 @@
       "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-2.0.0.tgz",
       "integrity": "sha1-7byQPMOF/ARSPZZqM1UEtVBNG9I=",
       "requires": {
-        "os-homedir": "1.0.2"
+        "os-homedir": "^1.0.0"
       }
     },
     "xml2js": {
@@ -2294,19 +2081,14 @@
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
       "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
       "requires": {
-        "sax": "1.2.4",
-        "xmlbuilder": "9.0.7"
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~9.0.1"
       }
     },
     "xmlbuilder": {
       "version": "9.0.7",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
       "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
-    },
-    "xmlhttprequest-ssl": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz",
-      "integrity": "sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4="
     },
     "yallist": {
       "version": "2.1.2",
@@ -2318,23 +2100,18 @@
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.15.0.tgz",
       "integrity": "sha1-PZRG7yH7N5GzmFaQZi5LloPH8YE=",
       "requires": {
-        "camelcase": "1.2.1",
-        "cliui": "2.1.0",
-        "decamelize": "1.2.0",
-        "window-size": "0.1.4"
+        "camelcase": "^1.0.2",
+        "cliui": "^2.1.0",
+        "decamelize": "^1.0.0",
+        "window-size": "^0.1.1"
       }
-    },
-    "yeast": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
-      "integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk="
     },
     "zip": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/zip/-/zip-1.2.0.tgz",
       "integrity": "sha1-rQrUImUwm+QutW/IYZThfCTmapw=",
       "requires": {
-        "bops": "0.1.1"
+        "bops": "~0.1.1"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -14,8 +14,7 @@
     "material-components-web": "^0.29.0",
     "ms": "^2.1.1",
     "rpio": "^0.9.20",
-    "snyk": "^1.69.10",
-    "socket.io": "^2.0.4"
+    "snyk": "^1.69.10"
   },
   "devDependencies": {},
   "repository": {

--- a/public/www/client.js
+++ b/public/www/client.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const Socket = io();
+const Events = new EventSource("/sse");
 let Snackbar = undefined;
 
 document.addEventListener("DOMContentLoaded", () => {
@@ -10,13 +10,13 @@ document.addEventListener("DOMContentLoaded", () => {
 	RegisterControls("door");
 	RegisterControls("gate");
 
-	Socket.on("message", Data =>
-		Snackbar.show({ message: Data }));
+	Events.addEventListener("message", Event =>
+		Snackbar.show({ message: Event.data }));
 });
 
 async function RegisterControls(Control) {
-	Socket.on(Control + "_status", Value => {
-		UpdateControls(Control, Value);
+	Events.addEventListener(Control + "_status", Event => {
+		UpdateControls(Control, JSON.parse(Event.data));
 	});
 
 	document.getElementById(Control + "-button").addEventListener("click", () => {

--- a/public/www/index.html
+++ b/public/www/index.html
@@ -10,7 +10,6 @@
 		<link rel="stylesheet" href="/style.css" />
 
 		<script defer src="/material-components-web.min.js"></script>
-		<script defer src="/socket.io.slim.js"></script>
 		<script defer src="/client.js"></script>
 
 		<link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png?v=7kbWjGl8xl" />

--- a/server.js
+++ b/server.js
@@ -50,7 +50,6 @@ App.use(Api.allowedMethods);
 Api.Register(Door);
 Api.Register(Gate);
 
-// TODO Check origin/referer
 const SSE = require("./sse");
 const EventManager = new SSE();
 App.use(mount("/sse", EventManager.SSE));

--- a/server.js
+++ b/server.js
@@ -47,26 +47,23 @@ const Api = new RestApi();
 App.use(Api.routes);
 App.use(Api.allowedMethods);
 
-Api.Register(Door);
-Api.Register(Gate);
-
 const SSE = require("./sse");
 const EventManager = new SSE();
 App.use(mount("/sse", EventManager.SSE));
 
-Door.on("open", () => {
-	EventManager.Broadcast("message", "Door opened");
-});
-Door.on("lock", Value => {
-	EventManager.Broadcast("door_status", JSON.stringify(Value));
-});
+function RegisterComponent(Component) {
+	Api.Register(Component);
 
-Gate.on("open", () => {
-	EventManager.Broadcast("message", "Gate opened");
-});
-Gate.on("lock", Value => {
-	EventManager.Broadcast("gate_status", JSON.stringify(Value));
-});
+	Component.on("open", () => {
+		EventManager.Broadcast("message", `${ Component.Name } opened`);
+	});
+	Component.on("lock", Value => {
+		EventManager.Broadcast(`${ Component.Name }_status`, JSON.stringify(Value));
+	});
+};
+
+RegisterComponent(Door);
+RegisterComponent(Gate);
 
 App.use(serve(path.join(__dirname, "public", "www"), { maxAge: ms("7d"), gzip: false, brotli: false }));
 App.use(serve(path.join(__dirname, "node_modules", "material-components-web", "dist"), { maxAge: ms("7d"), immutable: true, gzip: false, brotli: false }));

--- a/server.js
+++ b/server.js
@@ -72,15 +72,5 @@ App.use(serve(path.join(__dirname, "public", "www"), { maxAge: ms("7d"), gzip: f
 App.use(serve(path.join(__dirname, "node_modules", "material-components-web", "dist"), { maxAge: ms("7d"), immutable: true, gzip: false, brotli: false }));
 App.use(mount("/ca", serve(path.join(__dirname, "public", "ca"), { maxAge: ms("28d"), immutable: true, gzip: false, brotli: false })));
 
-function RegisterComponent(Socket, Id, Component) {
-	Socket.on(Component.Name + "_open", () => {
-		Component.Open(Id);
-	});
-	Socket.on(Component.Name + "_lock", Value => {
-		Component.Lock(Id, Value)
-	});
-	Socket.emit(Component.Name + "_status", Component.Locked);
-}
-
 Server.listen(443, "192.168.1.254", () =>
 	logger.Info("HTTPS", "listening on port", "443"));

--- a/sse.js
+++ b/sse.js
@@ -33,8 +33,6 @@ class EventStream extends Transform {
 
 class EventManager {
     constructor() {
-        super();
-
         this.Clients = [];
     };
 

--- a/sse.js
+++ b/sse.js
@@ -1,0 +1,91 @@
+const { Transform } = require("stream");
+const ms = require("ms");
+
+class EventStream extends Transform {
+    constructor() {
+        super({
+            writableObjectMode: true,
+            allowHalfOpen: false
+        });
+    };
+
+    _transform(Message, Encoding, Callback) {
+        let Result = `event: ${ Message.Event }\n`;
+        
+        const Data = Message.Data instanceof Array ? Message.Data : [ Message.Data ];
+        for (const Chunk of Data) {
+            Result += `data: ${ Chunk }\n`;
+        }
+
+        Result += "\n";
+
+        this.push(Result, "utf8");
+        Callback();
+    };
+
+    Send(event, data) {
+        this.write({
+            Event: event,
+            Data: data 
+        });
+    };
+};
+
+class EventManager {
+    constructor() {
+        super();
+
+        this.Clients = [];
+    };
+
+    Register() {
+        const Client = new EventStream();
+        this.Clients.push(Client);
+
+        Client.on("close", () => {
+            this.Clients = this.Clients.filter(x => x != Client);
+        });
+
+        return Client;
+    }
+
+    Middleware(ctx) {
+        ctx.assert(ctx.accepts("text/event-stream"), 403);
+    
+        ctx.type = "text/event-stream; charset=utf-8";
+        ctx.status = 200;
+        ctx.set("Cache-Control", "no-cache");
+        ctx.set("Connection", "keep-alive");
+        ctx.flushHeaders();
+    
+        ctx.req.setTimeout(ms("10m"));
+        ctx.req.socket.setNoDelay(true);
+    
+        ctx.body = this.Register();
+    };
+    
+    Broadcast(Event, Data) {
+        for (const Client of this.Clients) {
+            Client.Send(Event, Data);
+        }
+    };
+
+    get SSE() {
+        return this.Middleware.bind(this);
+    }
+};
+
+// module.exports = EventManager;
+
+// const Koa = require('koa');
+// const app = module.exports = new Koa();
+
+// const Manager = new EventManager();
+// Manager.on("client", Client => {
+//     Client.Send("hello", "hi client");
+//     Manager.Broadcast("notice", "new client in town");
+//     Manager.Broadcast("clients", Manager.Clients);
+// });
+
+// app.use(Manager.SSE);
+// app.listen(8000);

--- a/sse.js
+++ b/sse.js
@@ -11,7 +11,7 @@ class EventStream extends Transform {
 
     _transform(Message, Encoding, Callback) {
         let Result = `event: ${ Message.Event }\n`;
-        
+
         const Data = Message.Data instanceof Array ? Message.Data : [ Message.Data ];
         for (const Chunk of Data) {
             Result += `data: ${ Chunk }\n`;
@@ -26,7 +26,7 @@ class EventStream extends Transform {
     Send(event, data) {
         this.write({
             Event: event,
-            Data: data 
+            Data: data
         });
     };
 };
@@ -51,19 +51,19 @@ class EventManager {
 
     Middleware(ctx) {
         ctx.assert(ctx.accepts("text/event-stream"), 403);
-    
+
         ctx.type = "text/event-stream; charset=utf-8";
         ctx.status = 200;
         ctx.set("Cache-Control", "no-cache");
         ctx.set("Connection", "keep-alive");
         ctx.flushHeaders();
-    
+
         ctx.req.setTimeout(ms("10m"));
         ctx.req.socket.setNoDelay(true);
-    
+
         ctx.body = this.Register();
     };
-    
+
     Broadcast(Event, Data) {
         for (const Client of this.Clients) {
             Client.Send(Event, Data);

--- a/sse.js
+++ b/sse.js
@@ -73,7 +73,7 @@ class EventManager {
     }
 };
 
-// module.exports = EventManager;
+module.exports = EventManager;
 
 // const Koa = require('koa');
 // const app = module.exports = new Koa();

--- a/sse.js
+++ b/sse.js
@@ -74,16 +74,3 @@ class EventManager {
 };
 
 module.exports = EventManager;
-
-// const Koa = require('koa');
-// const app = module.exports = new Koa();
-
-// const Manager = new EventManager();
-// Manager.on("client", Client => {
-//     Client.Send("hello", "hi client");
-//     Manager.Broadcast("notice", "new client in town");
-//     Manager.Broadcast("clients", Manager.Clients);
-// });
-
-// app.use(Manager.SSE);
-// app.listen(8000);


### PR DESCRIPTION
WebSockets do not work with HTTP/2, so implement Server-Sent Events instead to replace them.
This also removes one of our major dependencies.